### PR TITLE
GAS: Add `OP_V` to `.insn` directive

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -749,7 +749,7 @@ static const struct opcode_name_t opcode_name_list[] =
   {"NMADD",     0x4f},
   {"NMSUB",     0x4b},
   {"OP_FP",     0x53},
-  /*reserved    0x57.  */
+  {"OP_V",      0x57},
   {"CUSTOM_2",  0x5b},
   /* 48b        0x5f.  */
 

--- a/gas/testsuite/gas/riscv/insn-dwarf.d
+++ b/gas/testsuite/gas/riscv/insn-dwarf.d
@@ -60,12 +60,13 @@ insn.s +53 +0x9a.*
 insn.s +54 +0x9e.*
 insn.s +55 +0xa2.*
 insn.s +57 +0xa6.*
-insn.s +58 +0xa8.*
-insn.s +59 +0xac.*
-insn.s +60 +0xb2.*
-insn.s +61 +0xba.*
-insn.s +62 +0xbc.*
-insn.s +63 +0xc0.*
-insn.s +64 +0xc6.*
-insn.s +- +0xce
+insn.s +59 +0xaa.*
+insn.s +60 +0xac.*
+insn.s +61 +0xb0.*
+insn.s +62 +0xb6.*
+insn.s +63 +0xbe.*
+insn.s +64 +0xc0.*
+insn.s +65 +0xc4.*
+insn.s +66 +0xca.*
+insn.s +- +0xd2
 #pass

--- a/gas/testsuite/gas/riscv/insn.d
+++ b/gas/testsuite/gas/riscv/insn.d
@@ -1,4 +1,4 @@
-#as: -march=rv32ifc
+#as: -march=rv32ifdcv
 #objdump: -dr
 
 .*:[ 	]+file format .*
@@ -69,6 +69,7 @@ Disassembly of section .text:
 [^:]+:[ 	]+00c58533[ 	]+add[ 	]+a0,a1,a2
 [^:]+:[ 	]+00c58533[ 	]+add[ 	]+a0,a1,a2
 [^:]+:[ 	]+00c58533[ 	]+add[ 	]+a0,a1,a2
+[^:]+:[ 	]+022180d7[ 	]+vadd\.vv[ 	]+v1,v2,v3
 [^:]+:[ 	]+0001[ 	]+nop
 [^:]+:[ 	]+00000013[ 	]+nop
 [^:]+:[ 	]+001f 0000 0000[ 	].*

--- a/gas/testsuite/gas/riscv/insn.s
+++ b/gas/testsuite/gas/riscv/insn.s
@@ -54,6 +54,8 @@ target:
 	.insn r  0x33,  0,  0, a0, fa1, fa2
 	.insn r  0x33,  0,  0, fa0, fa1, fa2
 
+	.insn r  OP_V, 0, 1, x1, x3, x2
+
 	.insn 0x0001
 	.insn 0x00000013
 	.insn 0x0000001f


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_gas_insn_opv