### PR TITLE
Disassembler: Cache instruction class support

### DIFF
--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -397,6 +397,8 @@ enum riscv_insn_class
   INSN_CLASS_ZICBOP,
   INSN_CLASS_ZICBOZ,
   INSN_CLASS_H,
+
+  NUM_INSN_CLASSES,
 };
 
 /* This structure holds information for a particular instruction.  */


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_dis_opts_cache_support