### PR TITLE
`sim/testsuite`: Trim extra path from arch

### DIFF
--- a/sim/testsuite/lib/sim-defs.exp
+++ b/sim/testsuite/lib/sim-defs.exp
@@ -14,7 +14,7 @@ proc sim_arch {} {
     while { [file dirname $arch] != "." } {
 	set arch [file dirname $arch]
     }
-    return "$arch"
+    return [file tail $arch]
 }
 
 # Initialize the testrun.


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/sim_trim_path_from_arch