### PR TITLE
RISC-V: Support mapping symbols with ISA string

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -487,7 +487,7 @@ make_mapping_symbol (enum riscv_seg_mstate state,
      following code will have the same value.  */
   if (value == 0)
     {
-       if (frag->tc_frag_data.first_map_symbol != NULL)
+      if (frag->tc_frag_data.first_map_symbol != NULL)
 	{
 	  know (S_GET_VALUE (frag->tc_frag_data.first_map_symbol)
 		== S_GET_VALUE (symbol));
@@ -529,7 +529,7 @@ riscv_mapping_state (enum riscv_seg_mstate to_state,
     return;
 
   /* The mapping symbol should be emitted if not in the right
-     mapping state  */
+     mapping state.  */
   if (from_state == to_state)
     return;
 

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -229,20 +229,20 @@ riscv_set_default_priv_spec (const char *s)
 /* This is the set of options which the .option pseudo-op may modify.  */
 struct riscv_set_options
 {
-  int pic; /* Generate position-independent code.  */
-  int rvc; /* Generate RVC code.  */
-  int relax; /* Emit relocs the linker is allowed to relax.  */
-  int arch_attr; /* Emit architecture and privileged elf attributes.  */
-  int csr_check; /* Enable the CSR checking.  */
+  bool pic; /* Generate position-independent code.  */
+  bool rvc; /* Generate RVC code.  */
+  bool relax; /* Emit relocs the linker is allowed to relax.  */
+  bool arch_attr; /* Emit architecture and privileged elf attributes.  */
+  bool csr_check; /* Enable the CSR checking.  */
 };
 
 static struct riscv_set_options riscv_opts =
 {
-  0, /* pic */
-  0, /* rvc */
-  1, /* relax */
-  DEFAULT_RISCV_ATTR, /* arch_attr */
-  0, /* csr_check */
+  false, /* pic */
+  false, /* rvc */
+  true,  /* relax */
+  (bool) DEFAULT_RISCV_ATTR, /* arch_attr */
+  false, /* csr_check */
 };
 
 /* Enable or disable the rvc flags for riscv_opts.  Turn on the rvc flag

--- a/gas/config/tc-riscv.h
+++ b/gas/config/tc-riscv.h
@@ -140,6 +140,11 @@ struct riscv_segment_info_type
   enum riscv_seg_mstate map_state;
 };
 
+#ifdef OBJ_ELF
+#define md_elf_section_change_hook() riscv_elf_section_change_hook ()
+extern void riscv_elf_section_change_hook (void);
+#endif
+
 /* Define target fragment type.  */
 #define TC_FRAG_TYPE struct riscv_frag_type
 struct riscv_frag_type

--- a/gas/testsuite/gas/riscv/mapping-01a.d
+++ b/gas/testsuite/gas/riscv/mapping-01a.d
@@ -8,10 +8,10 @@ SYMBOL TABLE:
 0+00 l    d  .text	0+00 .text
 0+00 l    d  .data	0+00 .data
 0+00 l    d  .bss	0+00 .bss
-0+00 l       .text	0+00 \$x
+0+00 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .foo	0+00 .foo
 0+00 l       .foo	0+00 foo
-0+00 l       .foo	0+00 \$x
+0+00 l       .foo	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .riscv.attributes	0+00 .riscv.attributes
 0+00 g       .text	0+00 funcA
 0+08 g       .text	0+00 funcB

--- a/gas/testsuite/gas/riscv/mapping-02a.d
+++ b/gas/testsuite/gas/riscv/mapping-02a.d
@@ -9,7 +9,7 @@ SYMBOL TABLE:
 0+00 l    d  .data	0+00 .data
 0+00 l    d  .bss	0+00 .bss
 0+00 l       .text	0+00 \$d
-0+04 l       .text	0+00 \$x
+0+04 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+0c l       .text	0+00 \$d
-0+0e l       .text	0+00 \$x
+0+0e l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-03a.d
+++ b/gas/testsuite/gas/riscv/mapping-03a.d
@@ -8,13 +8,13 @@ SYMBOL TABLE:
 0+00 l    d  .text	0+00 .text
 0+00 l    d  .data	0+00 .data
 0+00 l    d  .bss	0+00 .bss
-0+00 l       .text	0+00 \$x
+0+00 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+04 l       .text	0+00 \$d
-0+08 l       .text	0+00 \$x
+0+08 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+14 l       .text	0+00 \$d
-0+18 l       .text	0+00 \$x
+0+18 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+1c l       .text	0+00 \$d
-0+21 l       .text	0+00 \$x
+0+21 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+2d l       .text	0+00 \$d
-0+31 l       .text	0+00 \$x
+0+31 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-04a.d
+++ b/gas/testsuite/gas/riscv/mapping-04a.d
@@ -9,7 +9,7 @@ SYMBOL TABLE:
 0+00 l    d  .data	0+00 .data
 0+00 l    d  .bss	0+00 .bss
 0+00 l       .text	0+00 \$d
-0+0d l       .text	0+00 \$x
+0+0d l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+15 l       .text	0+00 \$d
-0+1f l       .text	0+00 \$x
+0+1f l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-05.s
+++ b/gas/testsuite/gas/riscv/mapping-05.s
@@ -1,0 +1,11 @@
+	.text
+	# F
+	fadd.s	f10, f11, f12
+	.option	arch, -f
+	.option	arch, +zfinx
+	# Zfinx
+	fadd.s	x10, x11, x12
+	.option	arch, -zfinx
+	.option	arch, +f
+	# F (RV32IF -F +Zfinx -Zfinx +F)
+	fadd.s	f10, f11, f12

--- a/gas/testsuite/gas/riscv/mapping-05a.d
+++ b/gas/testsuite/gas/riscv/mapping-05a.d
@@ -1,0 +1,14 @@
+#as: -march=rv32if
+#source: mapping-05.s
+#objdump: --syms --special-syms
+
+.*file format.*riscv.*
+
+SYMBOL TABLE:
+0+00 l    d  .text	0+00 .text
+0+00 l    d  .data	0+00 .data
+0+00 l    d  .bss	0+00 .bss
+0+00 l       .text	0+00 \$x
+0+04 l       .text	0+00 \$xrv32i2p1_zicsr2p0_zfinx1p0
+0+08 l       .text	0+00 \$xrv32i2p1_f2p2_zicsr2p0
+0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-05b.d
+++ b/gas/testsuite/gas/riscv/mapping-05b.d
@@ -1,0 +1,14 @@
+#as: -march=rv32if
+#source: mapping-05.s
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <.text>:
+[ 	]+0:[ 	]+00c5f553[ 	]+fadd\.s[ 	]+fa0,fa1,fa2
+[ 	]+4:[ 	]+00c5f553[ 	]+fadd\.s[ 	]+a0,a1,a2
+[ 	]+8:[ 	]+00c5f553[ 	]+fadd\.s[ 	]+fa0,fa1,fa2
+#...

--- a/gas/testsuite/gas/riscv/mapping-06.s
+++ b/gas/testsuite/gas/riscv/mapping-06.s
@@ -1,0 +1,11 @@
+	.text
+	# F
+	fadd.s	f10, f11, f12
+	.option	push
+	.option	arch, -f
+	.option	arch, +zfinx
+	# Zfinx
+	fadd.s	x10, x11, x12
+	.option	pop
+	# F (reverted to default)
+	fadd.s	f10, f11, f12

--- a/gas/testsuite/gas/riscv/mapping-06a.d
+++ b/gas/testsuite/gas/riscv/mapping-06a.d
@@ -1,0 +1,14 @@
+#as: -march=rv32if
+#source: mapping-06.s
+#objdump: --syms --special-syms
+
+.*file format.*riscv.*
+
+SYMBOL TABLE:
+0+00 l    d  .text	0+00 .text
+0+00 l    d  .data	0+00 .data
+0+00 l    d  .bss	0+00 .bss
+0+00 l       .text	0+00 \$x
+0+04 l       .text	0+00 \$xrv32i2p1_zicsr2p0_zfinx1p0
+0+08 l       .text	0+00 \$x
+0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-06b.d
+++ b/gas/testsuite/gas/riscv/mapping-06b.d
@@ -1,0 +1,14 @@
+#as: -march=rv32if
+#source: mapping-06.s
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <.text>:
+[ 	]+0:[ 	]+00c5f553[ 	]+fadd\.s[ 	]+fa0,fa1,fa2
+[ 	]+4:[ 	]+00c5f553[ 	]+fadd\.s[ 	]+a0,a1,a2
+[ 	]+8:[ 	]+00c5f553[ 	]+fadd\.s[ 	]+fa0,fa1,fa2
+#...

--- a/gas/testsuite/gas/riscv/mapping-07.s
+++ b/gas/testsuite/gas/riscv/mapping-07.s
@@ -1,0 +1,12 @@
+	.section	.text,  "ax", @progbits
+	add	a0, a1, a2
+	.section	.text2, "ax", @progbits
+	sub	a0, a1, a2
+	.section	.text,  "ax", @progbits
+	add	a0, a1, a2
+	.section	.text2, "ax", @progbits
+	sub	a0, a1, a2
+	.section	.text,  "ax", @progbits
+	add	a0, a1, a2
+	.section	.text2, "ax", @progbits
+	sub	a0, a1, a2

--- a/gas/testsuite/gas/riscv/mapping-07a.d
+++ b/gas/testsuite/gas/riscv/mapping-07a.d
@@ -1,0 +1,14 @@
+#as:
+#source: mapping-07.s
+#objdump: --syms --special-syms
+
+.*file format.*riscv.*
+
+SYMBOL TABLE:
+0+00 l    d  .text	0+00 .text
+0+00 l    d  .data	0+00 .data
+0+00 l    d  .bss	0+00 .bss
+0+00 l       .text	0+00 \$x
+0+00 l    d  .text2	0+00 .text2
+0+00 l       .text2	0+00 \$x
+0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-07b.d
+++ b/gas/testsuite/gas/riscv/mapping-07b.d
@@ -1,0 +1,21 @@
+#as:
+#source: mapping-07.s
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <.text>:
+[ 	]+0:[ 	]+00c58533[ 	]+add[ 	]+a0,a1,a2
+[ 	]+4:[ 	]+00c58533[ 	]+add[ 	]+a0,a1,a2
+[ 	]+8:[ 	]+00c58533[ 	]+add[ 	]+a0,a1,a2
+#...
+Disassembly of section .text2:
+
+0+000 <.text2>:
+[ 	]+0:[ 	]+40c58533[ 	]+sub[ 	]+a0,a1,a2
+[ 	]+4:[ 	]+40c58533[ 	]+sub[ 	]+a0,a1,a2
+[ 	]+8:[ 	]+40c58533[ 	]+sub[ 	]+a0,a1,a2
+#...

--- a/gas/testsuite/gas/riscv/mapping-08.s
+++ b/gas/testsuite/gas/riscv/mapping-08.s
@@ -1,0 +1,34 @@
+	.section	.text1,  "ax", @progbits
+	# (text1:0x0) Arch: default
+	add	a0, a0, a1
+	.option	push
+	.option	arch, +c
+
+	.section	.text2, "ax", @progbits
+	# (text2:0x0) Arch: +c
+	sub	a0, a0, a1
+	.option	pop
+
+	.section	.text1,  "ax", @progbits
+	# (text1:0x4) Arch: default (no change)
+	add	a0, a0, a1
+	.option	push
+	.option	arch, +c
+	# (text1:0x8) Arch: +c
+	add	a0, a0, a1
+
+	.section	.text2, "ax", @progbits
+	# (text2:0x2) Arch: +c (no change)
+	sub	a0, a0, a1
+	.option	arch, -c
+	# (text2:0x4) Arch: +c-c (not default)
+	sub	a0, a0, a1
+
+	.section	.text1,  "ax", @progbits
+	# (text1:0xa) Arch: +c-c (not default, changed from +c)
+	add	a0, a0, a1
+	.option	pop
+
+	.section	.text2, "ax", @progbits
+	# (text2:0x8) Arch: Default (changed from +c-c)
+	sub	a0, a0, a1

--- a/gas/testsuite/gas/riscv/mapping-08a.d
+++ b/gas/testsuite/gas/riscv/mapping-08a.d
@@ -1,0 +1,19 @@
+#as: -march=rv32i
+#source: mapping-08.s
+#objdump: --syms --special-syms
+
+.*file format.*riscv.*
+
+SYMBOL TABLE:
+0+00 l    d  .text	0+00 .text
+0+00 l    d  .data	0+00 .data
+0+00 l    d  .bss	0+00 .bss
+0+00 l    d  .text1	0+00 .text1
+0+00 l       .text1	0+00 \$x
+0+00 l    d  .text2	0+00 .text2
+0+00 l       .text2	0+00 \$xrv32i2p1_c2p0
+0+08 l       .text1	0+00 \$xrv32i2p1_c2p0
+0+04 l       .text2	0+00 \$xrv32i2p1
+0+0a l       .text1	0+00 \$xrv32i2p1
+0+08 l       .text2	0+00 \$x
+0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-08b.d
+++ b/gas/testsuite/gas/riscv/mapping-08b.d
@@ -1,0 +1,23 @@
+#as: -march=rv32i
+#source: mapping-08.s
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text1:
+
+0+000 <.text1>:
+[ 	]+0:[ 	]+00b50533[ 	]+add[ 	]+a0,a0,a1
+[ 	]+4:[ 	]+00b50533[ 	]+add[ 	]+a0,a0,a1
+[ 	]+8:[ 	]+952e[ 	]+add[ 	]+a0,a0,a1
+[ 	]+a:[ 	]+00b50533[ 	]+add[ 	]+a0,a0,a1
+#...
+Disassembly of section .text2:
+
+0+000 <.text2>:
+[ 	]+0:[ 	]+8d0d[ 	]+sub[ 	]+a0,a0,a1
+[ 	]+2:[ 	]+8d0d[ 	]+sub[ 	]+a0,a0,a1
+[ 	]+4:[ 	]+40b50533[ 	]+sub[ 	]+a0,a0,a1
+[ 	]+8:[ 	]+40b50533[ 	]+sub[ 	]+a0,a0,a1
+#...

--- a/gas/testsuite/gas/riscv/mapping-norelax-03a.d
+++ b/gas/testsuite/gas/riscv/mapping-norelax-03a.d
@@ -8,14 +8,14 @@ SYMBOL TABLE:
 0+00 l    d  .text	0+00 .text
 0+00 l    d  .data	0+00 .data
 0+00 l    d  .bss	0+00 .bss
-0+00 l       .text	0+00 \$x
+0+00 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+04 l       .text	0+00 \$d
-0+08 l       .text	0+00 \$x
+0+08 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+10 l       .text	0+00 \$d
-0+14 l       .text	0+00 \$x
+0+14 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+18 l       .text	0+00 \$d
 0+20 l       .text	0+00 \$d
-0+24 l       .text	0+00 \$x
+0+24 l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+1d l       .text	0+00 \$d
-0+1e l       .text	0+00 \$x
+0+1e l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/mapping-norelax-04a.d
+++ b/gas/testsuite/gas/riscv/mapping-norelax-04a.d
@@ -10,7 +10,7 @@ SYMBOL TABLE:
 0+00 l    d  .bss	0+00 .bss
 0+00 l       .text	0+00 \$d
 0+14 l       .text	0+00 \$d
-0+1e l       .text	0+00 \$x
+0+1e l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+0d l       .text	0+00 \$d
-0+0e l       .text	0+00 \$x
+0+0e l       .text	0+00 \$xrv64i2p1_m2p0_a2p1_f2p2_d2p2_zicsr2p0_zifencei2p0_zmmul1p0
 0+00 l    d  .riscv.attributes	0+00 .riscv.attributes

--- a/gas/testsuite/gas/riscv/option-arch-01a.d
+++ b/gas/testsuite/gas/riscv/option-arch-01a.d
@@ -10,5 +10,5 @@ Disassembly of section .text:
 0+000 <.text>:
 [ 	]+[0-9a-f]+:[  	]+952e[    	]+add[        	]+a0,a0,a1
 [ 	]+[0-9a-f]+:[  	]+00b50533[    	]+add[        	]+a0,a0,a1
-[ 	]+[0-9a-f]+:[  	]+00302573[    	]+csrr[        	]+a0,fcsr
+[ 	]+[0-9a-f]+:[  	]+00302573[    	]+frcsr[       	]+a0
 #...

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -806,7 +806,7 @@ riscv_get_map_state (int n,
     return false;
 
   name = bfd_asymbol_name(info->symtab[n]);
-  if (strcmp (name, "$x") == 0)
+  if (startswith (name, "$x"))
     *state = MAP_INSN;
   else if (strcmp (name, "$d") == 0)
     *state = MAP_DATA;

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -693,8 +693,8 @@ riscv_disassemble_insn (bfd_vma memaddr, insn_t word, disassemble_info *info)
 	  xlen = ehdr->e_ident[EI_CLASS] == ELFCLASS64 ? 64 : 32;
 	}
 
-      /* If arch has ZFINX flags, use gpr for disassemble.  */
-      if(riscv_subset_supports (&riscv_rps_dis, "zfinx"))
+      /* If arch has Zfinx extension, replace FPR with GPR.  */
+      if (riscv_subset_supports (&riscv_rps_dis, "zfinx"))
 	riscv_fpr_names = riscv_gpr_names;
 
       for (; op->name; op++)


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_mapping_sym_with_arch