### PR TITLE
psABI: Assign DWARF register numbers to vector registers

### DIFF
--- a/bfd/version.h
+++ b/bfd/version.h
@@ -16,7 +16,7 @@
 
    In releases, the date is not included in either version strings or
    sonames.  */
-#define BFD_VERSION_DATE 20221002
+#define BFD_VERSION_DATE 20221003
 #define BFD_VERSION @bfd_version@
 #define BFD_VERSION_STRING  @bfd_version_package@ @bfd_version_string@
 #define REPORT_BUGS_TO @report_bugs_to@

--- a/binutils/dwarf.c
+++ b/binutils/dwarf.c
@@ -8540,16 +8540,24 @@ init_dwarf_regnames_s390 (void)
 
 static const char *const dwarf_regnames_riscv[] =
 {
- "zero", "ra",   "sp",   "gp",  "tp",  "t0",  "t1",  "t2",  /* 0  - 7 */
- "s0",   "s1",   "a0",   "a1",  "a2",  "a3",  "a4",  "a5",  /* 8  - 15 */
- "a6",   "a7",   "s2",   "s3",  "s4",  "s5",  "s6",  "s7",  /* 16 - 23 */
- "s8",   "s9",   "s10",  "s11", "t3",  "t4",  "t5",  "t6",  /* 24 - 31 */
- "ft0",  "ft1",  "ft2",  "ft3", "ft4", "ft5", "ft6", "ft7", /* 32 - 39 */
- "fs0",  "fs1",                                             /* 40 - 41 */
- "fa0",  "fa1",  "fa2",  "fa3", "fa4", "fa5", "fa6", "fa7", /* 42 - 49 */
- "fs2",  "fs3",  "fs4",  "fs5", "fs6", "fs7", "fs8", "fs9", /* 50 - 57 */
- "fs10", "fs11",                                            /* 58 - 59 */
- "ft8",  "ft9",  "ft10", "ft11"                             /* 60 - 63 */
+ "zero", "ra",   "sp",   "gp",  "tp",  "t0",  "t1",  "t2",  /*   0 -   7 */
+ "s0",   "s1",   "a0",   "a1",  "a2",  "a3",  "a4",  "a5",  /*   8 -  15 */
+ "a6",   "a7",   "s2",   "s3",  "s4",  "s5",  "s6",  "s7",  /*  16 -  23 */
+ "s8",   "s9",   "s10",  "s11", "t3",  "t4",  "t5",  "t6",  /*  24 -  31 */
+ "ft0",  "ft1",  "ft2",  "ft3", "ft4", "ft5", "ft6", "ft7", /*  32 -  39 */
+ "fs0",  "fs1",                                             /*  40 -  41 */
+ "fa0",  "fa1",  "fa2",  "fa3", "fa4", "fa5", "fa6", "fa7", /*  42 -  49 */
+ "fs2",  "fs3",  "fs4",  "fs5", "fs6", "fs7", "fs8", "fs9", /*  50 -  57 */
+ "fs10", "fs11",                                            /*  58 -  59 */
+ "ft8",  "ft9",  "ft10", "ft11",                            /*  60 -  63 */
+ NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,     /*  64 -  71 */
+ NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,     /*  72 -  79 */
+ NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,     /*  80 -  87 */
+ NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,  NULL,     /*  88 -  95 */
+ "v0",  "v1",  "v2",  "v3",  "v4",  "v5",  "v6",  "v7",     /*  96 - 103 */
+ "v8",  "v9",  "v10", "v11", "v12", "v13", "v14", "v15",    /* 104 - 111 */
+ "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",    /* 112 - 119 */
+ "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31",    /* 120 - 127 */
 };
 
 /* A RISC-V replacement for REGNAME_INTERNAL_BY_TABLE_ONLY which handles

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -4406,6 +4406,9 @@ tc_riscv_regname_to_dw2regnum (char *regname)
   if ((reg = reg_lookup_internal (regname, RCLASS_FPR)) >= 0)
     return reg + 32;
 
+  if ((reg = reg_lookup_internal (regname, RCLASS_VECR)) >= 0)
+    return reg + 96;
+
   /* CSRs are numbered 4096 -> 8191.  */
   if ((reg = reg_lookup_internal (regname, RCLASS_CSR)) >= 0)
     return reg + 4096;

--- a/gas/testsuite/gas/riscv/dw-regnums.d
+++ b/gas/testsuite/gas/riscv/dw-regnums.d
@@ -1,4 +1,4 @@
-#as: -march=rv32if
+#as: -march=rv32iv
 #objdump: --dwarf=frames
 
 
@@ -145,4 +145,36 @@ Contents of the .* section:
   DW_CFA_offset_extended_sf: r61 \(ft9\) at cfa\+248
   DW_CFA_offset_extended_sf: r62 \(ft10\) at cfa\+252
   DW_CFA_offset_extended_sf: r63 \(ft11\) at cfa\+256
+  DW_CFA_offset_extended_sf: r96 \(v0\) at cfa\+388
+  DW_CFA_offset_extended_sf: r97 \(v1\) at cfa\+392
+  DW_CFA_offset_extended_sf: r98 \(v2\) at cfa\+396
+  DW_CFA_offset_extended_sf: r99 \(v3\) at cfa\+400
+  DW_CFA_offset_extended_sf: r100 \(v4\) at cfa\+404
+  DW_CFA_offset_extended_sf: r101 \(v5\) at cfa\+408
+  DW_CFA_offset_extended_sf: r102 \(v6\) at cfa\+412
+  DW_CFA_offset_extended_sf: r103 \(v7\) at cfa\+416
+  DW_CFA_offset_extended_sf: r104 \(v8\) at cfa\+420
+  DW_CFA_offset_extended_sf: r105 \(v9\) at cfa\+424
+  DW_CFA_offset_extended_sf: r106 \(v10\) at cfa\+428
+  DW_CFA_offset_extended_sf: r107 \(v11\) at cfa\+432
+  DW_CFA_offset_extended_sf: r108 \(v12\) at cfa\+436
+  DW_CFA_offset_extended_sf: r109 \(v13\) at cfa\+440
+  DW_CFA_offset_extended_sf: r110 \(v14\) at cfa\+444
+  DW_CFA_offset_extended_sf: r111 \(v15\) at cfa\+448
+  DW_CFA_offset_extended_sf: r112 \(v16\) at cfa\+452
+  DW_CFA_offset_extended_sf: r113 \(v17\) at cfa\+456
+  DW_CFA_offset_extended_sf: r114 \(v18\) at cfa\+460
+  DW_CFA_offset_extended_sf: r115 \(v19\) at cfa\+464
+  DW_CFA_offset_extended_sf: r116 \(v20\) at cfa\+468
+  DW_CFA_offset_extended_sf: r117 \(v21\) at cfa\+472
+  DW_CFA_offset_extended_sf: r118 \(v22\) at cfa\+476
+  DW_CFA_offset_extended_sf: r119 \(v23\) at cfa\+480
+  DW_CFA_offset_extended_sf: r120 \(v24\) at cfa\+484
+  DW_CFA_offset_extended_sf: r121 \(v25\) at cfa\+488
+  DW_CFA_offset_extended_sf: r122 \(v26\) at cfa\+492
+  DW_CFA_offset_extended_sf: r123 \(v27\) at cfa\+496
+  DW_CFA_offset_extended_sf: r124 \(v28\) at cfa\+500
+  DW_CFA_offset_extended_sf: r125 \(v29\) at cfa\+504
+  DW_CFA_offset_extended_sf: r126 \(v30\) at cfa\+508
+  DW_CFA_offset_extended_sf: r127 \(v31\) at cfa\+512
 #...

--- a/gas/testsuite/gas/riscv/dw-regnums.d
+++ b/gas/testsuite/gas/riscv/dw-regnums.d
@@ -1,0 +1,148 @@
+#as: -march=rv32if
+#objdump: --dwarf=frames
+
+
+.*:     file format elf.*-.*riscv
+
+Contents of the .* section:
+
+
+00000000 [a-zA-Z0-9]+ [a-zA-Z0-9]+ CIE
+  Version:               .*
+  Augmentation:          .*
+  Code alignment factor: .*
+  Data alignment factor: .*
+  Return address column: .*
+  Augmentation data:     .*
+#...
+[a-zA-Z0-9]+ [a-zA-Z0-9]+ [a-zA-Z0-9]+ FDE cie=00000000 pc=[a-zA-Z0-9]+\.\.[a-zA-Z0-9]+
+  DW_CFA_advance_loc: 4 to 0+0000020
+  DW_CFA_offset_extended_sf: r0 \(zero\) at cfa\+4
+  DW_CFA_offset_extended_sf: r1 \(ra\) at cfa\+8
+  DW_CFA_offset_extended_sf: r2 \(sp\) at cfa\+12
+  DW_CFA_offset_extended_sf: r3 \(gp\) at cfa\+16
+  DW_CFA_offset_extended_sf: r4 \(tp\) at cfa\+20
+  DW_CFA_offset_extended_sf: r5 \(t0\) at cfa\+24
+  DW_CFA_offset_extended_sf: r6 \(t1\) at cfa\+28
+  DW_CFA_offset_extended_sf: r7 \(t2\) at cfa\+32
+  DW_CFA_offset_extended_sf: r8 \(s0\) at cfa\+36
+  DW_CFA_offset_extended_sf: r9 \(s1\) at cfa\+40
+  DW_CFA_offset_extended_sf: r10 \(a0\) at cfa\+44
+  DW_CFA_offset_extended_sf: r11 \(a1\) at cfa\+48
+  DW_CFA_offset_extended_sf: r12 \(a2\) at cfa\+52
+  DW_CFA_offset_extended_sf: r13 \(a3\) at cfa\+56
+  DW_CFA_offset_extended_sf: r14 \(a4\) at cfa\+60
+  DW_CFA_offset_extended_sf: r15 \(a5\) at cfa\+64
+  DW_CFA_offset_extended_sf: r16 \(a6\) at cfa\+68
+  DW_CFA_offset_extended_sf: r17 \(a7\) at cfa\+72
+  DW_CFA_offset_extended_sf: r18 \(s2\) at cfa\+76
+  DW_CFA_offset_extended_sf: r19 \(s3\) at cfa\+80
+  DW_CFA_offset_extended_sf: r20 \(s4\) at cfa\+84
+  DW_CFA_offset_extended_sf: r21 \(s5\) at cfa\+88
+  DW_CFA_offset_extended_sf: r22 \(s6\) at cfa\+92
+  DW_CFA_offset_extended_sf: r23 \(s7\) at cfa\+96
+  DW_CFA_offset_extended_sf: r24 \(s8\) at cfa\+100
+  DW_CFA_offset_extended_sf: r25 \(s9\) at cfa\+104
+  DW_CFA_offset_extended_sf: r26 \(s10\) at cfa\+108
+  DW_CFA_offset_extended_sf: r27 \(s11\) at cfa\+112
+  DW_CFA_offset_extended_sf: r28 \(t3\) at cfa\+116
+  DW_CFA_offset_extended_sf: r29 \(t4\) at cfa\+120
+  DW_CFA_offset_extended_sf: r30 \(t5\) at cfa\+124
+  DW_CFA_offset_extended_sf: r31 \(t6\) at cfa\+128
+  DW_CFA_offset_extended_sf: r0 \(zero\) at cfa\+4
+  DW_CFA_offset_extended_sf: r1 \(ra\) at cfa\+8
+  DW_CFA_offset_extended_sf: r2 \(sp\) at cfa\+12
+  DW_CFA_offset_extended_sf: r3 \(gp\) at cfa\+16
+  DW_CFA_offset_extended_sf: r4 \(tp\) at cfa\+20
+  DW_CFA_offset_extended_sf: r5 \(t0\) at cfa\+24
+  DW_CFA_offset_extended_sf: r6 \(t1\) at cfa\+28
+  DW_CFA_offset_extended_sf: r7 \(t2\) at cfa\+32
+  DW_CFA_offset_extended_sf: r8 \(s0\) at cfa\+36
+  DW_CFA_offset_extended_sf: r9 \(s1\) at cfa\+40
+  DW_CFA_offset_extended_sf: r10 \(a0\) at cfa\+44
+  DW_CFA_offset_extended_sf: r11 \(a1\) at cfa\+48
+  DW_CFA_offset_extended_sf: r12 \(a2\) at cfa\+52
+  DW_CFA_offset_extended_sf: r13 \(a3\) at cfa\+56
+  DW_CFA_offset_extended_sf: r14 \(a4\) at cfa\+60
+  DW_CFA_offset_extended_sf: r15 \(a5\) at cfa\+64
+  DW_CFA_offset_extended_sf: r16 \(a6\) at cfa\+68
+  DW_CFA_offset_extended_sf: r17 \(a7\) at cfa\+72
+  DW_CFA_offset_extended_sf: r18 \(s2\) at cfa\+76
+  DW_CFA_offset_extended_sf: r19 \(s3\) at cfa\+80
+  DW_CFA_offset_extended_sf: r20 \(s4\) at cfa\+84
+  DW_CFA_offset_extended_sf: r21 \(s5\) at cfa\+88
+  DW_CFA_offset_extended_sf: r22 \(s6\) at cfa\+92
+  DW_CFA_offset_extended_sf: r23 \(s7\) at cfa\+96
+  DW_CFA_offset_extended_sf: r24 \(s8\) at cfa\+100
+  DW_CFA_offset_extended_sf: r25 \(s9\) at cfa\+104
+  DW_CFA_offset_extended_sf: r26 \(s10\) at cfa\+108
+  DW_CFA_offset_extended_sf: r27 \(s11\) at cfa\+112
+  DW_CFA_offset_extended_sf: r28 \(t3\) at cfa\+116
+  DW_CFA_offset_extended_sf: r29 \(t4\) at cfa\+120
+  DW_CFA_offset_extended_sf: r30 \(t5\) at cfa\+124
+  DW_CFA_offset_extended_sf: r31 \(t6\) at cfa\+128
+  DW_CFA_offset_extended_sf: r32 \(ft0\) at cfa\+132
+  DW_CFA_offset_extended_sf: r33 \(ft1\) at cfa\+136
+  DW_CFA_offset_extended_sf: r34 \(ft2\) at cfa\+140
+  DW_CFA_offset_extended_sf: r35 \(ft3\) at cfa\+144
+  DW_CFA_offset_extended_sf: r36 \(ft4\) at cfa\+148
+  DW_CFA_offset_extended_sf: r37 \(ft5\) at cfa\+152
+  DW_CFA_offset_extended_sf: r38 \(ft6\) at cfa\+156
+  DW_CFA_offset_extended_sf: r39 \(ft7\) at cfa\+160
+  DW_CFA_offset_extended_sf: r40 \(fs0\) at cfa\+164
+  DW_CFA_offset_extended_sf: r41 \(fs1\) at cfa\+168
+  DW_CFA_offset_extended_sf: r42 \(fa0\) at cfa\+172
+  DW_CFA_offset_extended_sf: r43 \(fa1\) at cfa\+176
+  DW_CFA_offset_extended_sf: r44 \(fa2\) at cfa\+180
+  DW_CFA_offset_extended_sf: r45 \(fa3\) at cfa\+184
+  DW_CFA_offset_extended_sf: r46 \(fa4\) at cfa\+188
+  DW_CFA_offset_extended_sf: r47 \(fa5\) at cfa\+192
+  DW_CFA_offset_extended_sf: r48 \(fa6\) at cfa\+196
+  DW_CFA_offset_extended_sf: r49 \(fa7\) at cfa\+200
+  DW_CFA_offset_extended_sf: r50 \(fs2\) at cfa\+204
+  DW_CFA_offset_extended_sf: r51 \(fs3\) at cfa\+208
+  DW_CFA_offset_extended_sf: r52 \(fs4\) at cfa\+212
+  DW_CFA_offset_extended_sf: r53 \(fs5\) at cfa\+216
+  DW_CFA_offset_extended_sf: r54 \(fs6\) at cfa\+220
+  DW_CFA_offset_extended_sf: r55 \(fs7\) at cfa\+224
+  DW_CFA_offset_extended_sf: r56 \(fs8\) at cfa\+228
+  DW_CFA_offset_extended_sf: r57 \(fs9\) at cfa\+232
+  DW_CFA_offset_extended_sf: r58 \(fs10\) at cfa\+236
+  DW_CFA_offset_extended_sf: r59 \(fs11\) at cfa\+240
+  DW_CFA_offset_extended_sf: r60 \(ft8\) at cfa\+244
+  DW_CFA_offset_extended_sf: r61 \(ft9\) at cfa\+248
+  DW_CFA_offset_extended_sf: r62 \(ft10\) at cfa\+252
+  DW_CFA_offset_extended_sf: r63 \(ft11\) at cfa\+256
+  DW_CFA_offset_extended_sf: r32 \(ft0\) at cfa\+132
+  DW_CFA_offset_extended_sf: r33 \(ft1\) at cfa\+136
+  DW_CFA_offset_extended_sf: r34 \(ft2\) at cfa\+140
+  DW_CFA_offset_extended_sf: r35 \(ft3\) at cfa\+144
+  DW_CFA_offset_extended_sf: r36 \(ft4\) at cfa\+148
+  DW_CFA_offset_extended_sf: r37 \(ft5\) at cfa\+152
+  DW_CFA_offset_extended_sf: r38 \(ft6\) at cfa\+156
+  DW_CFA_offset_extended_sf: r39 \(ft7\) at cfa\+160
+  DW_CFA_offset_extended_sf: r40 \(fs0\) at cfa\+164
+  DW_CFA_offset_extended_sf: r41 \(fs1\) at cfa\+168
+  DW_CFA_offset_extended_sf: r42 \(fa0\) at cfa\+172
+  DW_CFA_offset_extended_sf: r43 \(fa1\) at cfa\+176
+  DW_CFA_offset_extended_sf: r44 \(fa2\) at cfa\+180
+  DW_CFA_offset_extended_sf: r45 \(fa3\) at cfa\+184
+  DW_CFA_offset_extended_sf: r46 \(fa4\) at cfa\+188
+  DW_CFA_offset_extended_sf: r47 \(fa5\) at cfa\+192
+  DW_CFA_offset_extended_sf: r48 \(fa6\) at cfa\+196
+  DW_CFA_offset_extended_sf: r49 \(fa7\) at cfa\+200
+  DW_CFA_offset_extended_sf: r50 \(fs2\) at cfa\+204
+  DW_CFA_offset_extended_sf: r51 \(fs3\) at cfa\+208
+  DW_CFA_offset_extended_sf: r52 \(fs4\) at cfa\+212
+  DW_CFA_offset_extended_sf: r53 \(fs5\) at cfa\+216
+  DW_CFA_offset_extended_sf: r54 \(fs6\) at cfa\+220
+  DW_CFA_offset_extended_sf: r55 \(fs7\) at cfa\+224
+  DW_CFA_offset_extended_sf: r56 \(fs8\) at cfa\+228
+  DW_CFA_offset_extended_sf: r57 \(fs9\) at cfa\+232
+  DW_CFA_offset_extended_sf: r58 \(fs10\) at cfa\+236
+  DW_CFA_offset_extended_sf: r59 \(fs11\) at cfa\+240
+  DW_CFA_offset_extended_sf: r60 \(ft8\) at cfa\+244
+  DW_CFA_offset_extended_sf: r61 \(ft9\) at cfa\+248
+  DW_CFA_offset_extended_sf: r62 \(ft10\) at cfa\+252
+  DW_CFA_offset_extended_sf: r63 \(ft11\) at cfa\+256
+#...

--- a/gas/testsuite/gas/riscv/dw-regnums.s
+++ b/gas/testsuite/gas/riscv/dw-regnums.s
@@ -1,0 +1,148 @@
+# Check that CFI directives can accept all of the register names (including
+# aliases).  The results for this test also ensures that the DWARF
+# register numbers for the GPRs/FPRs registers shouldn't change.
+
+	.text
+	.global _start
+_start:
+	.cfi_startproc
+	nop
+
+	# GPRs (ABI)
+	.cfi_offset zero,  4
+	.cfi_offset ra,    8
+	.cfi_offset sp,   12
+	.cfi_offset gp,   16
+	.cfi_offset tp,   20
+	.cfi_offset t0,   24
+	.cfi_offset t1,   28
+	.cfi_offset t2,   32
+	.cfi_offset s0,   36
+	.cfi_offset s1,   40
+	.cfi_offset a0,   44
+	.cfi_offset a1,   48
+	.cfi_offset a2,   52
+	.cfi_offset a3,   56
+	.cfi_offset a4,   60
+	.cfi_offset a5,   64
+	.cfi_offset a6,   68
+	.cfi_offset a7,   72
+	.cfi_offset s2,   76
+	.cfi_offset s3,   80
+	.cfi_offset s4,   84
+	.cfi_offset s5,   88
+	.cfi_offset s6,   92
+	.cfi_offset s7,   96
+	.cfi_offset s8,  100
+	.cfi_offset s9,  104
+	.cfi_offset s10, 108
+	.cfi_offset s11, 112
+	.cfi_offset t3,  116
+	.cfi_offset t4,  120
+	.cfi_offset t5,  124
+	.cfi_offset t6,  128
+
+	# GPRs (Numeric)
+	.cfi_offset x0,    4
+	.cfi_offset x1,    8
+	.cfi_offset x2,   12
+	.cfi_offset x3,   16
+	.cfi_offset x4,   20
+	.cfi_offset x5,   24
+	.cfi_offset x6,   28
+	.cfi_offset x7,   32
+	.cfi_offset x8,   36
+	.cfi_offset x9,   40
+	.cfi_offset x10,  44
+	.cfi_offset x11,  48
+	.cfi_offset x12,  52
+	.cfi_offset x13,  56
+	.cfi_offset x14,  60
+	.cfi_offset x15,  64
+	.cfi_offset x16,  68
+	.cfi_offset x17,  72
+	.cfi_offset x18,  76
+	.cfi_offset x19,  80
+	.cfi_offset x20,  84
+	.cfi_offset x21,  88
+	.cfi_offset x22,  92
+	.cfi_offset x23,  96
+	.cfi_offset x24, 100
+	.cfi_offset x25, 104
+	.cfi_offset x26, 108
+	.cfi_offset x27, 112
+	.cfi_offset x28, 116
+	.cfi_offset x29, 120
+	.cfi_offset x30, 124
+	.cfi_offset x31, 128
+
+	# FPRs (ABI)
+	.cfi_offset ft0,  132
+	.cfi_offset ft1,  136
+	.cfi_offset ft2,  140
+	.cfi_offset ft3,  144
+	.cfi_offset ft4,  148
+	.cfi_offset ft5,  152
+	.cfi_offset ft6,  156
+	.cfi_offset ft7,  160
+	.cfi_offset fs0,  164
+	.cfi_offset fs1,  168
+	.cfi_offset fa0,  172
+	.cfi_offset fa1,  176
+	.cfi_offset fa2,  180
+	.cfi_offset fa3,  184
+	.cfi_offset fa4,  188
+	.cfi_offset fa5,  192
+	.cfi_offset fa6,  196
+	.cfi_offset fa7,  200
+	.cfi_offset fs2,  204
+	.cfi_offset fs3,  208
+	.cfi_offset fs4,  212
+	.cfi_offset fs5,  216
+	.cfi_offset fs6,  220
+	.cfi_offset fs7,  224
+	.cfi_offset fs8,  228
+	.cfi_offset fs9,  232
+	.cfi_offset fs10, 236
+	.cfi_offset fs11, 240
+	.cfi_offset ft8,  244
+	.cfi_offset ft9,  248
+	.cfi_offset ft10, 252
+	.cfi_offset ft11, 256
+
+	# FPRs (Numeric)
+	.cfi_offset f0,  132
+	.cfi_offset f1,  136
+	.cfi_offset f2,  140
+	.cfi_offset f3,  144
+	.cfi_offset f4,  148
+	.cfi_offset f5,  152
+	.cfi_offset f6,  156
+	.cfi_offset f7,  160
+	.cfi_offset f8,  164
+	.cfi_offset f9,  168
+	.cfi_offset f10, 172
+	.cfi_offset f11, 176
+	.cfi_offset f12, 180
+	.cfi_offset f13, 184
+	.cfi_offset f14, 188
+	.cfi_offset f15, 192
+	.cfi_offset f16, 196
+	.cfi_offset f17, 200
+	.cfi_offset f18, 204
+	.cfi_offset f19, 208
+	.cfi_offset f20, 212
+	.cfi_offset f21, 216
+	.cfi_offset f22, 220
+	.cfi_offset f23, 224
+	.cfi_offset f24, 228
+	.cfi_offset f25, 232
+	.cfi_offset f26, 236
+	.cfi_offset f27, 240
+	.cfi_offset f28, 244
+	.cfi_offset f29, 248
+	.cfi_offset f30, 252
+	.cfi_offset f31, 256
+
+	nop
+	.cfi_endproc

--- a/gas/testsuite/gas/riscv/dw-regnums.s
+++ b/gas/testsuite/gas/riscv/dw-regnums.s
@@ -1,6 +1,8 @@
 # Check that CFI directives can accept all of the register names (including
 # aliases).  The results for this test also ensures that the DWARF
-# register numbers for the GPRs/FPRs registers shouldn't change.
+# register numbers for the GPRs/FPRs/vector registers shouldn't change.
+# Note that, because vector register size is "variable" in principle,
+# vector registers are very unlikely to be used within .cfi_offset directive.
 
 	.text
 	.global _start
@@ -143,6 +145,40 @@ _start:
 	.cfi_offset f29, 248
 	.cfi_offset f30, 252
 	.cfi_offset f31, 256
+
+	# Vector registers (numeric only)
+	.cfi_offset v0,  388
+	.cfi_offset v1,  392
+	.cfi_offset v2,  396
+	.cfi_offset v3,  400
+	.cfi_offset v4,  404
+	.cfi_offset v5,  408
+	.cfi_offset v6,  412
+	.cfi_offset v7,  416
+	.cfi_offset v8,  420
+	.cfi_offset v9,  424
+	.cfi_offset v10, 428
+	.cfi_offset v11, 432
+	.cfi_offset v12, 436
+	.cfi_offset v13, 440
+	.cfi_offset v14, 444
+	.cfi_offset v15, 448
+	.cfi_offset v16, 452
+	.cfi_offset v17, 456
+	.cfi_offset v18, 460
+	.cfi_offset v19, 464
+	.cfi_offset v20, 468
+	.cfi_offset v21, 472
+	.cfi_offset v22, 476
+	.cfi_offset v23, 480
+	.cfi_offset v24, 484
+	.cfi_offset v25, 488
+	.cfi_offset v26, 492
+	.cfi_offset v27, 496
+	.cfi_offset v28, 500
+	.cfi_offset v29, 504
+	.cfi_offset v30, 508
+	.cfi_offset v31, 512
 
 	nop
 	.cfi_endproc

--- a/gdb/testsuite/gdb.threads/next-fork-other-thread.c
+++ b/gdb/testsuite/gdb.threads/next-fork-other-thread.c
@@ -44,7 +44,7 @@ forker (void *arg)
       do
 	{
 	  ret = waitpid (pid, &stat, 0);
-	} while (ret == EINTR);
+	} while (ret == -1 && errno == EINTR);
 
       assert (ret == pid);
       assert (WIFEXITED (stat));


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_psabi_dwarf_vector_regs