### PR TITLE
`sim`: Remove redundant self assignment statements

### DIFF
--- a/sim/common/hw-tree.c
+++ b/sim/common/hw-tree.c
@@ -335,7 +335,6 @@ split_find_device (struct hw *current,
       else if (strncmp (spec->path, "./", strlen ("./")) == 0)
 	{
 	  /* cd ./... */
-	  current = current;
 	  spec->path += strlen ("./");
 	}
       else if (strncmp (spec->path, "../", strlen ("../")) == 0)
@@ -348,7 +347,6 @@ split_find_device (struct hw *current,
       else if (strcmp (spec->path, ".") == 0)
 	{
 	  /* cd . */
-	  current = current;
 	  spec->path += strlen (".");
 	}
       else if (strcmp (spec->path, "..") == 0)

--- a/sim/ppc/tree.c
+++ b/sim/ppc/tree.c
@@ -306,7 +306,6 @@ split_find_device(device *current,
     }
     else if (strncmp(spec->path, "./", strlen("./")) == 0) {
       /* cd ./... */
-      current = current;
       spec->path += strlen("./");
     }
     else if (strncmp(spec->path, "../", strlen("../")) == 0) {
@@ -317,7 +316,6 @@ split_find_device(device *current,
     }
     else if (strcmp(spec->path, ".") == 0) {
       /* cd . */
-      current = current;
       spec->path += strlen(".");
     }
     else if (strcmp(spec->path, "..") == 0) {


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/sim_clang_nowarn_1