### PR TITLE
`gdb`, `opcodes`: Add non-enum disassembler options

### DIFF
--- a/gdb/disasm.c
+++ b/gdb/disasm.c
@@ -1270,6 +1270,8 @@ set_disassembler_options (const char *prospective_options)
 	    if (memcmp (opt, valid_options->name[i], len) != 0)
 	      continue;
 	    arg = opt + len;
+	    if (valid_options->arg[i]->values == NULL)
+	      break;
 	    for (j = 0; valid_options->arg[i]->values[j] != NULL; j++)
 	      if (disassembler_options_cmp
 		    (arg, valid_options->arg[i]->values[j]) == 0)
@@ -1391,6 +1393,8 @@ The following disassembler options are supported for use with the\n\
 
       for (i = 0; valid_args[i].name != NULL; i++)
 	{
+	  if (valid_args[i].values == NULL)
+	    continue;
 	  gdb_printf (file, _("\n\
   For the options above, the following values are supported for \"%s\":\n   "),
 		      valid_args[i].name);

--- a/include/dis-asm.h
+++ b/include/dis-asm.h
@@ -318,7 +318,8 @@ typedef struct
   /* Option argument name to use in descriptions.  */
   const char *name;
 
-  /* Vector of acceptable option argument values, NULL-terminated.  */
+  /* Vector of acceptable option argument values, NULL-terminated.
+     NULL if any values are accepted.  */
   const char **values;
 } disasm_option_arg_t;
 

--- a/opcodes/arc-dis.c
+++ b/opcodes/arc-dis.c
@@ -1611,6 +1611,8 @@ print_arc_disassembler_options (FILE *stream)
   for (i = 0; args[i].name != NULL; ++i)
     {
       size_t len = 3;
+      if (args[i].values == NULL)
+	continue;
       fprintf (stream, _("\n\
   For the options above, the following values are supported for \"%s\":\n   "),
 	       args[i].name);

--- a/opcodes/mips-dis.c
+++ b/opcodes/mips-dis.c
@@ -2809,6 +2809,8 @@ with the -M switch (multiple options should be separated by commas):\n\n"));
 
   for (i = 0; args[i].name != NULL; i++)
     {
+      if (args[i].values == NULL)
+	continue;
       fprintf (stream, _("\n\
   For the options above, the following values are supported for \"%s\":\n   "),
 	       args[i].name);

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -1195,6 +1195,8 @@ with the -M switch (multiple options should be separated by commas):\n"));
 
   for (i = 0; args[i].name != NULL; i++)
     {
+      if (args[i].values == NULL)
+	continue;
       fprintf (stream, _("\n\
   For the options above, the following values are supported for \"%s\":\n   "),
 	       args[i].name);


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/gdb_opcodes_add_nonenum_disasm_opts