### PR TITLE
Fix: `RV32EF` conflict no longer exists

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -1876,13 +1876,6 @@ riscv_parse_check_conflicts (riscv_parse_subset_t *rps)
       rps->error_handler (_("rv%d does not support the `q' extension"), xlen);
       no_conflict = false;
     }
-  if (riscv_lookup_subset (rps->subset_list, "e", &subset)
-      && riscv_lookup_subset (rps->subset_list, "f", &subset))
-    {
-      rps->error_handler
-        (_("rv32e does not support the `f' extension"));
-      no_conflict = false;
-    }
   if (riscv_lookup_subset (rps->subset_list, "zfinx", &subset)
       && riscv_lookup_subset (rps->subset_list, "f", &subset))
     {

--- a/gas/testsuite/gas/riscv/march-fail-rv32ef.d
+++ b/gas/testsuite/gas/riscv/march-fail-rv32ef.d
@@ -1,3 +1,0 @@
-#as: -march=rv32ef
-#source: empty.s
-#error_output: march-fail-rv32ef.l

--- a/gas/testsuite/gas/riscv/march-fail-rv32ef.l
+++ b/gas/testsuite/gas/riscv/march-fail-rv32ef.l
@@ -1,2 +1,0 @@
-.*Assembler messages:
-.*Error: .*rv32e does not support the `f' extension


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_ext_rv32ef_fix