### PR TITLE
Clang: Stop using `-Wstack-usage=262144` when built with Clang

### DIFF
--- a/bfd/configure
+++ b/bfd/configure
@@ -12093,7 +12093,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -12138,7 +12147,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 

--- a/bfd/warning.m4
+++ b/bfd/warning.m4
@@ -50,7 +50,8 @@ GCC_WARN_CFLAGS_FOR_BUILD="-W -Wall -Wstrict-prototypes -Wmissing-prototypes"
 AC_EGREP_CPP([(^[0-3]$|^__GNUC__$)],[__GNUC__],,GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wshadow")
 
 # Add -Wstack-usage if the compiler is a sufficiently recent version of GCC.
-AC_EGREP_CPP([(^[0-4]$|^__GNUC__$)],[__GNUC__],,GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144")
+AC_EGREP_CPP([(^[0-4]$|^__GNUC__$)],[__GNUC__],,dnl
+[AC_EGREP_CPP([^__clang__$],[__clang__],[GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"],)])
 
 # Set WARN_WRITE_STRINGS if the compiler supports -Wwrite-strings.
 WARN_WRITE_STRINGS=""
@@ -62,7 +63,8 @@ AC_EGREP_CPP([(^[0-3]$|^__GNUC__$)],[__GNUC__],,WARN_WRITE_STRINGS="-Wwrite-stri
 AC_EGREP_CPP_FOR_BUILD([(^[0-3]$|^__GNUC__$)],[__GNUC__],,GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wshadow")
 
 # Add -Wstack-usage if the compiler is a sufficiently recent version of GCC.
-AC_EGREP_CPP_FOR_BUILD([(^[0-4]$|^__GNUC__$)],[__GNUC__],,GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144")
+AC_EGREP_CPP_FOR_BUILD([(^[0-4]$|^__GNUC__$)],[__GNUC__],,dnl
+[AC_EGREP_CPP_FOR_BUILD([^__clang__$],[__clang__],[GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"],)])
 
 AC_ARG_ENABLE(werror,
   [  --enable-werror         treat compile warnings as errors],

--- a/binutils/configure
+++ b/binutils/configure
@@ -11932,7 +11932,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -11977,7 +11986,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 

--- a/gas/configure
+++ b/gas/configure
@@ -11588,7 +11588,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -11633,7 +11642,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 

--- a/gold/configure
+++ b/gold/configure
@@ -7938,7 +7938,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -7983,7 +7992,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 

--- a/gprof/configure
+++ b/gprof/configure
@@ -11890,7 +11890,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -11935,7 +11944,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 

--- a/ld/configure
+++ b/ld/configure
@@ -15855,7 +15855,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -15900,7 +15909,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 

--- a/opcodes/configure
+++ b/opcodes/configure
@@ -11445,7 +11445,16 @@ if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS="$GCC_WARN_CFLAGS -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 
@@ -11490,7 +11499,16 @@ if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
   $EGREP "(^[0-4]$|^__GNUC__$)" >/dev/null 2>&1; then :
 
 else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+__clang__
+_ACEOF
+if (eval "$ac_cpp_for_build conftest.$ac_ext") 2>&5 |
+  $EGREP "^__clang__$" >/dev/null 2>&1; then :
   GCC_WARN_CFLAGS_FOR_BUILD="$GCC_WARN_CFLAGS_FOR_BUILD -Wstack-usage=262144"
+fi
+rm -f conftest*
+
 fi
 rm -f conftest*
 


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/clang_nowarn_wstack_usage_262144