### PR TITLE
Clang: Suppress warnings if built with Clang (`gdb`)

### DIFF
--- a/gdb/unittests/string_view-selftests.c
+++ b/gdb/unittests/string_view-selftests.c
@@ -23,6 +23,11 @@
 
 #define GNULIB_NAMESPACE gnulib
 
+#include "diagnostics.h"
+
+DIAGNOSTIC_PUSH
+DIAGNOSTIC_IGNORE_USER_DEFINED_WARNINGS
+
 #include "defs.h"
 #include "gdbsupport/selftest.h"
 #include "gdbsupport/gdb_string_view.h"
@@ -33,6 +38,8 @@
 #include <sstream>
 #include <fstream>
 #include <iostream>
+
+DIAGNOSTIC_POP
 
 /* libstdc++'s testsuite uses VERIFY.  */
 #define VERIFY SELF_CHECK


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/clang_nowarn_gdb_generic_failures