### PR TITLE
Clang: Suppress warnings if built with Clang (`gold`)

### DIFF
--- a/gold/yyscript.y
+++ b/gold/yyscript.y
@@ -26,6 +26,7 @@
 %{
 
 #include "config.h"
+#include "diagnostics.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -33,6 +34,8 @@
 #include <string.h>
 
 #include "script-c.h"
+
+DIAGNOSTIC_IGNORE_UNUSED_BUT_SET_VARIABLE
 
 %}
 


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/clang_nowarn_gold_suppress_bison