### PR TITLE
Cleaning: Move certain Arrays

### DIFF
--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -46,17 +46,6 @@ static inline unsigned int riscv_insn_length (insn_t insn)
   return 2;
 }
 
-static const char * const riscv_rm[8] =
-{
-  "rne", "rtz", "rdn", "rup", "rmm", 0, 0, "dyn"
-};
-
-static const char * const riscv_pred_succ[16] =
-{
-  0,   "w",  "r",  "rw",  "o",  "ow",  "or",  "orw",
-  "i", "iw", "ir", "irw", "io", "iow", "ior", "iorw"
-};
-
 #define RVC_JUMP_BITS 11
 #define RVC_JUMP_REACH ((1ULL << RVC_JUMP_BITS) * RISCV_JUMP_ALIGN)
 
@@ -555,6 +544,8 @@ extern const char * const riscv_gpr_names_numeric[NGPR];
 extern const char * const riscv_gpr_names_abi[NGPR];
 extern const char * const riscv_fpr_names_numeric[NFPR];
 extern const char * const riscv_fpr_names_abi[NFPR];
+extern const char * const riscv_rm[8];
+extern const char * const riscv_pred_succ[16];
 extern const char * const riscv_vecr_names_numeric[NVECR];
 extern const char * const riscv_vecm_names_numeric[NVECM];
 extern const char * const riscv_vsew[8];

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -58,6 +58,19 @@ const char * const riscv_fpr_names_abi[NFPR] =
   "fs8",  "fs9",  "fs10", "fs11", "ft8",  "ft9",  "ft10", "ft11"
 };
 
+/* Rounding modes.  */
+const char * const riscv_rm[8] =
+{
+  "rne", "rtz", "rdn", "rup", "rmm", 0, 0, "dyn"
+};
+
+/* FENCE: predecessor/successor sets.  */
+const char * const riscv_pred_succ[16] =
+{
+  0,   "w",  "r",  "rw",  "o",  "ow",  "or",  "orw",
+  "i", "iw", "ir", "irw", "io", "iow", "ior", "iorw"
+};
+
 /* RVV registers.  */
 const char * const riscv_vecr_names_numeric[NVECR] =
 {


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_opcode_tidying_move_arrays