### PR TITLE
Cleaning: Remove unused substitution (`binutils`, `@PROGRAM@`)

### DIFF
--- a/binutils/Makefile.in
+++ b/binutils/Makefile.in
@@ -2136,8 +2136,7 @@ doc/$(DEMANGLER_NAME).1: doc/cxxfilt.man Makefile doc/$(am__dirstamp)
 	else \
 	  man=$(srcdir)/doc/cxxfilt.man; \
 	fi; \
-	sed -e 's/@PROGRAM@/$(DEMANGLER_NAME)/' \
-	    -e 's/cxxfilt/$(DEMANGLER_NAME)/' < $$man \
+	sed -e 's/cxxfilt/$(DEMANGLER_NAME)/' < $$man \
 		> doc/$(DEMANGLER_NAME).1
 
 html-local: doc/binutils/index.html

--- a/binutils/doc/local.mk
+++ b/binutils/doc/local.mk
@@ -169,8 +169,7 @@ MAINTAINERCLEANFILES += $(man_MANS) %D%/binutils.info %D%/cxxfilt.man
 	else \
 	  man=$(srcdir)/%D%/cxxfilt.man; \
 	fi; \
-	sed -e 's/@PROGRAM@/$(DEMANGLER_NAME)/' \
-	    -e 's/cxxfilt/$(DEMANGLER_NAME)/' < $$man \
+	sed -e 's/cxxfilt/$(DEMANGLER_NAME)/' < $$man \
 		> %D%/$(DEMANGLER_NAME).1
 
 html-local: %D%/binutils/index.html


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/binutils_remove_unused_subst