### PR TITLE
GCC: Define macro to disable `-Wdeprecated-declarations`

### DIFF
--- a/include/diagnostics.h
+++ b/include/diagnostics.h
@@ -78,6 +78,9 @@
 
 #elif defined (__GNUC__) /* GCC */
 
+# define DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS \
+  DIAGNOSTIC_IGNORE ("-Wdeprecated-declarations")
+
 # if __GNUC__ >= 7
 #  define DIAGNOSTIC_IGNORE_DEPRECATED_REGISTER \
    DIAGNOSTIC_IGNORE ("-Wregister")


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/gcc_nowarn_deprecated_decl