### PR TITLE
Fix: Build failure on RISC-V mapping symbol handling with GCC 12

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -484,7 +484,7 @@ make_mapping_symbol (enum riscv_seg_mstate state,
 		     bool reset_seg_arch_str)
 {
   const char *name;
-  char *buff;
+  char *buff = NULL;
   switch (state)
     {
     case MAP_DATA:


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_gas_mapping_syms_failure_1