### PR TITLE
GAS: Enable RVC when `Zca` is enabled via `.option arch`

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -4376,7 +4376,8 @@ s_riscv_option (int x ATTRIBUTE_UNUSED)
       riscv_reset_subsets_list_arch_str ();
 
       riscv_set_rvc (false);
-      if (riscv_subset_supports (&riscv_rps_as, "c"))
+      if (riscv_subset_supports (&riscv_rps_as, "c")
+	  || riscv_subset_supports (&riscv_rps_as, "zca"))
 	riscv_set_rvc (true);
 
       if (riscv_subset_supports (&riscv_rps_as, "ztso"))


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_gas_option_arch_zca