### PR TITLE
Extension: `Zve32f`, `Zve64f` and `Zve64d` with `Zfinx`-based configuration

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -1110,12 +1110,10 @@ static struct riscv_implicit_subset riscv_implicit_subsets[] =
   {"v", "d",		check_implicit_always},
   {"v", "zve64d",	check_implicit_always},
   {"v", "zvl128b",	check_implicit_always},
-  {"zve64d", "d",	check_implicit_always},
   {"zve64d", "zve64f",	check_implicit_always},
   {"zve64f", "zve32f",	check_implicit_always},
   {"zve64f", "zve64x",	check_implicit_always},
   {"zve64f", "zvl64b",	check_implicit_always},
-  {"zve32f", "f",	check_implicit_always},
   {"zve32f", "zvl32b",	check_implicit_always},
   {"zve32f", "zve32x",	check_implicit_always},
   {"zve64x", "zve32x",	check_implicit_always},
@@ -1965,6 +1963,27 @@ riscv_parse_check_conflicts (riscv_parse_subset_t *rps)
       rps->error_handler
 	(_("`zfinx' is conflict with the `f/d/q/zfh/zfhmin' extension"));
       no_conflict = false;
+    }
+
+  if (riscv_lookup_subset (rps->subset_list, "zve32f", &subset)
+      && !riscv_lookup_subset (rps->subset_list, "v", &subset))
+    {
+      if (riscv_lookup_subset (rps->subset_list, "zve32f", &subset)
+	  && !riscv_lookup_subset (rps->subset_list, "f", &subset)
+	  && !riscv_lookup_subset (rps->subset_list, "zfinx", &subset))
+	{
+	  rps->error_handler
+	    (_("`zve32f' requires either `f/zfinx' extension"));
+	  no_conflict = false;
+	}
+      if (riscv_lookup_subset (rps->subset_list, "zve64d", &subset)
+	  && !riscv_lookup_subset (rps->subset_list, "d", &subset)
+	  && !riscv_lookup_subset (rps->subset_list, "zdinx", &subset))
+	{
+	  rps->error_handler
+	    (_("`zve64d' requires either `d/zdinx' extension"));
+	  no_conflict = false;
+	}
     }
 
   bool support_zve = false;

--- a/gas/testsuite/gas/riscv/march-fail-rv32i_zve32f.d
+++ b/gas/testsuite/gas/riscv/march-fail-rv32i_zve32f.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_zve32f
+#source: empty.s
+#error_output: march-fail-rv32i_zve32f.l

--- a/gas/testsuite/gas/riscv/march-fail-rv32i_zve32f.l
+++ b/gas/testsuite/gas/riscv/march-fail-rv32i_zve32f.l
@@ -1,0 +1,2 @@
+.*Assembler messages:
+.*Error: .*`zve32f' requires either `f/zfinx' extension

--- a/gas/testsuite/gas/riscv/march-fail-rv32i_zve64d.d
+++ b/gas/testsuite/gas/riscv/march-fail-rv32i_zve64d.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_zve64d
+#source: empty.s
+#error_output: march-fail-rv32i_zve64d.l

--- a/gas/testsuite/gas/riscv/march-fail-rv32i_zve64d.l
+++ b/gas/testsuite/gas/riscv/march-fail-rv32i_zve64d.l
@@ -1,0 +1,3 @@
+.*Assembler messages:
+.*Error: .*`zve32f' requires either `f/zfinx' extension
+.*Error: .*`zve64d' requires either `d/zdinx' extension

--- a/gas/testsuite/gas/riscv/vector-insns-fail-zve32xf.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-zve32xf.d
@@ -1,3 +1,3 @@
-#as: -march=rv32i_zve32f
+#as: -march=rv32if_zve32f
 #source: vector-insns.s
 #error_output: vector-insns-fail-zve32xf.l

--- a/gas/testsuite/gas/riscv/vector-insns-zve64d-zdinx.d
+++ b/gas/testsuite/gas/riscv/vector-insns-zve64d-zdinx.d
@@ -1,0 +1,85 @@
+#as: -march=rv32i_zfinx_zdinx_zve64d
+#objdump: -dr
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <.text>:
+[ 	]+[0-9a-f]+:[ 	]+02865257[ 	]+vfadd.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+00865257[ 	]+vfadd.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+0a865257[ 	]+vfsub.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+08865257[ 	]+vfsub.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+9e865257[ 	]+vfrsub.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+9c865257[ 	]+vfrsub.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+c2865257[ 	]+vfwadd.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+c0865257[ 	]+vfwadd.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+ca865257[ 	]+vfwsub.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+c8865257[ 	]+vfwsub.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+d2865257[ 	]+vfwadd.wf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+d0865257[ 	]+vfwadd.wf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+da865257[ 	]+vfwsub.wf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+d8865257[ 	]+vfwsub.wf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+92865257[ 	]+vfmul.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+90865257[ 	]+vfmul.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+82865257[ 	]+vfdiv.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+80865257[ 	]+vfdiv.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+86865257[ 	]+vfrdiv.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+84865257[ 	]+vfrdiv.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+e2865257[ 	]+vfwmul.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+e0865257[ 	]+vfwmul.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+a2865257[ 	]+vfmadd.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+a6865257[ 	]+vfnmadd.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+aa865257[ 	]+vfmsub.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+ae865257[ 	]+vfnmsub.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+a0865257[ 	]+vfmadd.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+a4865257[ 	]+vfnmadd.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+a8865257[ 	]+vfmsub.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+ac865257[ 	]+vfnmsub.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+b2865257[ 	]+vfmacc.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+b6865257[ 	]+vfnmacc.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+ba865257[ 	]+vfmsac.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+be865257[ 	]+vfnmsac.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+b0865257[ 	]+vfmacc.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+b4865257[ 	]+vfnmacc.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+b8865257[ 	]+vfmsac.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+bc865257[ 	]+vfnmsac.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+f2865257[ 	]+vfwmacc.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+f6865257[ 	]+vfwnmacc.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+fa865257[ 	]+vfwmsac.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+fe865257[ 	]+vfwnmsac.vf[ 	]+v4,a2,v8
+[ 	]+[0-9a-f]+:[ 	]+f0865257[ 	]+vfwmacc.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+f4865257[ 	]+vfwnmacc.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+f8865257[ 	]+vfwmsac.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+fc865257[ 	]+vfwnmsac.vf[ 	]+v4,a2,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+12865257[ 	]+vfmin.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+1a865257[ 	]+vfmax.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+10865257[ 	]+vfmin.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+18865257[ 	]+vfmax.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+22865257[ 	]+vfsgnj.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+26865257[ 	]+vfsgnjn.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+2a865257[ 	]+vfsgnjx.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+20865257[ 	]+vfsgnj.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+24865257[ 	]+vfsgnjn.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+28865257[ 	]+vfsgnjx.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+62865257[ 	]+vmfeq.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+72865257[ 	]+vmfne.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+6e865257[ 	]+vmflt.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+66865257[ 	]+vmfle.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+76865257[ 	]+vmfgt.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+7e865257[ 	]+vmfge.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+60865257[ 	]+vmfeq.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+70865257[ 	]+vmfne.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+6c865257[ 	]+vmflt.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+64865257[ 	]+vmfle.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+74865257[ 	]+vmfgt.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+7c865257[ 	]+vmfge.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+5c865257[ 	]+vfmerge.vfm[ 	]+v4,v8,a2,v0
+[ 	]+[0-9a-f]+:[ 	]+5e065257[ 	]+vfmv.v.f[ 	]+v4,a2
+[ 	]+[0-9a-f]+:[ 	]+42801557[ 	]+vfmv.f.s[ 	]+a0,v8
+[ 	]+[0-9a-f]+:[ 	]+42065257[ 	]+vfmv.s.f[ 	]+v4,a2
+[ 	]+[0-9a-f]+:[ 	]+3a865257[ 	]+vfslide1up.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+3e865257[ 	]+vfslide1down.vf[ 	]+v4,v8,a2
+[ 	]+[0-9a-f]+:[ 	]+38865257[ 	]+vfslide1up.vf[ 	]+v4,v8,a2,v0.t
+[ 	]+[0-9a-f]+:[ 	]+3c865257[ 	]+vfslide1down.vf[ 	]+v4,v8,a2,v0.t

--- a/gas/testsuite/gas/riscv/vector-insns-zve64d-zdinx.s
+++ b/gas/testsuite/gas/riscv/vector-insns-zve64d-zdinx.s
@@ -1,0 +1,87 @@
+	vfadd.vf v4, v8, a2
+	vfadd.vf v4, v8, a2, v0.t
+	vfsub.vf v4, v8, a2
+	vfsub.vf v4, v8, a2, v0.t
+	vfrsub.vf v4, v8, a2
+	vfrsub.vf v4, v8, a2, v0.t
+
+	vfwadd.vf v4, v8, a2
+	vfwadd.vf v4, v8, a2, v0.t
+	vfwsub.vf v4, v8, a2
+	vfwsub.vf v4, v8, a2, v0.t
+	vfwadd.wf v4, v8, a2
+	vfwadd.wf v4, v8, a2, v0.t
+	vfwsub.wf v4, v8, a2
+	vfwsub.wf v4, v8, a2, v0.t
+
+	vfmul.vf v4, v8, a2
+	vfmul.vf v4, v8, a2, v0.t
+	vfdiv.vf v4, v8, a2
+	vfdiv.vf v4, v8, a2, v0.t
+	vfrdiv.vf v4, v8, a2
+	vfrdiv.vf v4, v8, a2, v0.t
+
+	vfwmul.vf v4, v8, a2
+	vfwmul.vf v4, v8, a2, v0.t
+
+	vfmadd.vf v4, a2, v8
+	vfnmadd.vf v4, a2, v8
+	vfmsub.vf v4, a2, v8
+	vfnmsub.vf v4, a2, v8
+	vfmadd.vf v4, a2, v8, v0.t
+	vfnmadd.vf v4, a2, v8, v0.t
+	vfmsub.vf v4, a2, v8, v0.t
+	vfnmsub.vf v4, a2, v8, v0.t
+	vfmacc.vf v4, a2, v8
+	vfnmacc.vf v4, a2, v8
+	vfmsac.vf v4, a2, v8
+	vfnmsac.vf v4, a2, v8
+	vfmacc.vf v4, a2, v8, v0.t
+	vfnmacc.vf v4, a2, v8, v0.t
+	vfmsac.vf v4, a2, v8, v0.t
+	vfnmsac.vf v4, a2, v8, v0.t
+
+	vfwmacc.vf v4, a2, v8
+	vfwnmacc.vf v4, a2, v8
+	vfwmsac.vf v4, a2, v8
+	vfwnmsac.vf v4, a2, v8
+	vfwmacc.vf v4, a2, v8, v0.t
+	vfwnmacc.vf v4, a2, v8, v0.t
+	vfwmsac.vf v4, a2, v8, v0.t
+	vfwnmsac.vf v4, a2, v8, v0.t
+
+	vfmin.vf v4, v8, a2
+	vfmax.vf v4, v8, a2
+	vfmin.vf v4, v8, a2, v0.t
+	vfmax.vf v4, v8, a2, v0.t
+
+	vfsgnj.vf v4, v8, a2
+	vfsgnjn.vf v4, v8, a2
+	vfsgnjx.vf v4, v8, a2
+	vfsgnj.vf v4, v8, a2, v0.t
+	vfsgnjn.vf v4, v8, a2, v0.t
+	vfsgnjx.vf v4, v8, a2, v0.t
+
+	vmfeq.vf v4, v8, a2
+	vmfne.vf v4, v8, a2
+	vmflt.vf v4, v8, a2
+	vmfle.vf v4, v8, a2
+	vmfgt.vf v4, v8, a2
+	vmfge.vf v4, v8, a2
+	vmfeq.vf v4, v8, a2, v0.t
+	vmfne.vf v4, v8, a2, v0.t
+	vmflt.vf v4, v8, a2, v0.t
+	vmfle.vf v4, v8, a2, v0.t
+	vmfgt.vf v4, v8, a2, v0.t
+	vmfge.vf v4, v8, a2, v0.t
+
+	vfmerge.vfm v4, v8, a2, v0
+	vfmv.v.f v4, a2
+
+	vfmv.f.s a0, v8
+	vfmv.s.f v4, a2
+
+	vfslide1up.vf v4, v8, a2
+	vfslide1down.vf v4, v8, a2
+	vfslide1up.vf v4, v8, a2, v0.t
+	vfslide1down.vf v4, v8, a2, v0.t


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_zvef_allow_zfinx