### PR TITLE
Fix: Add conflicting combination `E` and `H`

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -1949,6 +1949,13 @@ riscv_parse_check_conflicts (riscv_parse_subset_t *rps)
 	(_("rv%d does not support the `e' extension"), xlen);
       no_conflict = false;
     }
+  if (riscv_subset_supports (rps, "e")
+      && riscv_subset_supports (rps, "h"))
+    {
+      rps->error_handler
+	(_("rv%de does not support the `h' extension"), xlen);
+      no_conflict = false;
+    }
   if (riscv_lookup_subset (rps->subset_list, "q", &subset)
       && (subset->major_version < 2 || (subset->major_version == 2
 					&& subset->minor_version < 2))

--- a/gas/testsuite/gas/riscv/march-fail-rv32eh.d
+++ b/gas/testsuite/gas/riscv/march-fail-rv32eh.d
@@ -1,0 +1,3 @@
+#as: -march=rv32eh
+#source: empty.s
+#error_output: march-fail-rv32eh.l

--- a/gas/testsuite/gas/riscv/march-fail-rv32eh.l
+++ b/gas/testsuite/gas/riscv/march-fail-rv32eh.l
@@ -1,0 +1,2 @@
+.*Assembler messages:
+.*Error: .*rv32e does not support the `h' extension


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_ext_rve_h_fix