### PR TITLE
Fix: Stub VLEN support on GDB (1)

### DIFF
--- a/gdb/arch/riscv.h
+++ b/gdb/arch/riscv.h
@@ -47,9 +47,10 @@ struct riscv_gdbarch_features
   int flen = 0;
 
   /* The size of the v-registers in bytes.  The value 0 indicates a target
-     with no vector registers.  The minimum value for a standard compliant
-     target should be 16, but GDB doesn't currently mind, and will accept
-     any vector size.  */
+     with no vector registers.  The minimum value for a 'V'-extension compliant
+     target should be 16 and 4 for an embedded subset compliant target (with
+     'Zve32*' extension), but GDB doesn't currently mind, and will accept any
+     vector size.  */
   int vlen = 0;
 
   /* When true this target is RV32E.  */

--- a/gdb/arch/riscv.h
+++ b/gdb/arch/riscv.h
@@ -90,7 +90,7 @@ struct riscv_gdbarch_features
 		       | (has_fcsr_reg ? 1 : 0) << 13
 		       | (xlen & 0x1f) << 5
 		       | (flen & 0x1f) << 0
-		       | (vlen & 0xfff) << 14);
+		       | (vlen & 0x3fff) << 14);
     return val;
   }
 };


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/gdb_riscv_stub_vlen_1