### PR TITLE
Extension: Make `XVentanaCondOps` instructions RV64-only

### DIFF
--- a/gas/testsuite/gas/riscv/x-ventana-condops-32.d
+++ b/gas/testsuite/gas/riscv/x-ventana-condops-32.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xventanacondops
+#source: x-ventana-condops.s
+#error_output: x-ventana-condops-32.l

--- a/gas/testsuite/gas/riscv/x-ventana-condops-32.l
+++ b/gas/testsuite/gas/riscv/x-ventana-condops-32.l
@@ -1,0 +1,3 @@
+.*Assembler messages:
+.*Error: unrecognized opcode `vt.maskc a0,a1,a2'
+.*Error: unrecognized opcode `vt.maskcn a0,a3,a4'

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -2174,8 +2174,8 @@ const struct riscv_opcode riscv_opcodes[] =
 {"th.sync.s",        0, INSN_CLASS_XTHEADSYNC,  "",   MATCH_TH_SYNC_S,        MASK_TH_SYNC_S,        match_opcode, 0},
 
 /* Vendor-specific (Ventana Microsystems) XVentanaCondOps instructions */
-{"vt.maskc",    0, INSN_CLASS_XVENTANACONDOPS, "d,s,t", MATCH_VT_MASKC, MASK_VT_MASKC, match_opcode, 0 },
-{"vt.maskcn",   0, INSN_CLASS_XVENTANACONDOPS, "d,s,t", MATCH_VT_MASKCN, MASK_VT_MASKCN, match_opcode, 0 },
+{"vt.maskc",   64, INSN_CLASS_XVENTANACONDOPS, "d,s,t", MATCH_VT_MASKC, MASK_VT_MASKC, match_opcode, 0 },
+{"vt.maskcn",  64, INSN_CLASS_XVENTANACONDOPS, "d,s,t", MATCH_VT_MASKCN, MASK_VT_MASKCN, match_opcode, 0 },
 
 /* Terminate the list.  */
 {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}


### PR DESCRIPTION
Wiki Page (details): https://github.com/a4lg/binutils-gdb/wiki/riscv_ext_xventanacondops_xlen